### PR TITLE
fix: 타인페이지 구독 취소 invalidate 구분

### DIFF
--- a/src/components/OtherPage/SellerBannerOther.tsx
+++ b/src/components/OtherPage/SellerBannerOther.tsx
@@ -45,8 +45,8 @@ export default function SellerBannerOther({ sellerInfo, slug }: Props) {
 
   const cancelsubscribe = useMutation(() => cancelSubscribe(slug || ''), {
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['isSubscribed','subscribeUsers'] });
-
+      queryClient.invalidateQueries({ queryKey: ['isSubscribed'] });
+      queryClient.invalidateQueries({ queryKey: ['subscribeUsers'] });
     },
   });
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1LGFrku5qIadXF24OqE5PHEmiL5ntUzk%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=dlFJAy_)